### PR TITLE
Fix About button crash

### DIFF
--- a/core/src/main/java/com/wafitz/pixelspacebase/scenes/AboutScene.java
+++ b/core/src/main/java/com/wafitz/pixelspacebase/scenes/AboutScene.java
@@ -37,7 +37,8 @@ import com.watabou.noosa.Image;
 import com.watabou.noosa.RenderedText;
 import com.watabou.noosa.TouchArea;
 
-class AboutScene extends PixelScene {
+// Game.switchScene uses reflection, so this class must be public
+public class AboutScene extends PixelScene {
 
     private static final String TTL_PS = "Pixel Spacebase";
 


### PR DESCRIPTION
## Summary
- make `AboutScene` public so `Game.switchScene` can create it
- configure Android SDK so unit tests run

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686bf0089c90832686ed68b764dcaf84