### PR TITLE
Use logger for exception reporting

### DIFF
--- a/pd-classes/src/main/java/com/watabou/gltextures/TextureCache.java
+++ b/pd-classes/src/main/java/com/watabou/gltextures/TextureCache.java
@@ -29,6 +29,8 @@ import com.watabou.glwrap.Texture;
 
 import java.util.HashMap;
 
+import com.watabou.utils.Logger;
+
 public class TextureCache {
 
 	public static Context context;
@@ -147,13 +149,13 @@ public class TextureCache {
 				return null;
 				
 			}
-		} catch (Exception e) {
-			
-			e.printStackTrace();
-			return null;
-			
-		}
-	}
+               } catch (Exception e) {
+
+                       Logger.e("Failed to load bitmap from " + src, e);
+                       return null;
+
+               }
+       }
 	
 	public static boolean contains( Object key ) {
 		return all.containsKey( key );

--- a/pd-classes/src/main/java/com/watabou/noosa/Game.java
+++ b/pd-classes/src/main/java/com/watabou/noosa/Game.java
@@ -44,6 +44,7 @@ import com.watabou.noosa.audio.Music;
 import com.watabou.noosa.audio.Sample;
 import com.watabou.utils.BitmapCache;
 import com.watabou.utils.SystemTime;
+import com.watabou.utils.Logger;
 
 import java.util.ArrayList;
 
@@ -288,11 +289,11 @@ public class Game extends Activity implements GLSurfaceView.Renderer, View.OnTou
 			try {
 				requestedScene = sceneClass.newInstance();
 				switchScene();
-			} catch (InstantiationException e){
-				e.printStackTrace();
-			} catch (IllegalAccessException e) {
-				e.printStackTrace();
-			}
+                       } catch (InstantiationException e){
+                               Logger.e("Unable to instantiate scene " + sceneClass, e);
+                       } catch (IllegalAccessException e) {
+                               Logger.e("Illegal access while creating scene " + sceneClass, e);
+                       }
 
 		}
 		

--- a/pd-classes/src/main/java/com/watabou/noosa/Group.java
+++ b/pd-classes/src/main/java/com/watabou/noosa/Group.java
@@ -23,6 +23,7 @@ package com.watabou.noosa;
 
 import com.watabou.noosa.particles.Emitter;
 import com.watabou.utils.Random;
+import com.watabou.utils.Logger;
 
 import java.util.ArrayList;
 
@@ -188,11 +189,11 @@ public class Group extends Gizmo {
 			
 		} else {
 			
-			try {
-				return add( c.newInstance() );
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
+                       try {
+                               return add( c.newInstance() );
+                       } catch (Exception e) {
+                               Logger.e("Unable to recycle gizmo " + c, e);
+                       }
 		}
 		
 		return null;

--- a/pd-classes/src/main/java/com/watabou/utils/Logger.java
+++ b/pd-classes/src/main/java/com/watabou/utils/Logger.java
@@ -1,0 +1,11 @@
+package com.watabou.utils;
+
+import android.util.Log;
+
+public class Logger {
+	private static final String TAG = "PD";
+
+	public static void e(String message, Throwable tr) {
+	Log.e(TAG, message, tr);
+	}
+}


### PR DESCRIPTION
## Summary
- add simple Logger utility
- log bitmap load failures
- log scene creation errors
- log gizmo recycling failures

## Testing
- `./gradlew assemble` *(fails: Could not initialize class org.codehaus.groovy.runtime.InvokerHelper)*

------
https://chatgpt.com/codex/tasks/task_e_686bf45115108326972a3731c4129ba7