### PR TITLE
Switch to mavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
@@ -33,6 +33,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }


### PR DESCRIPTION
## Summary
- replace `jcenter()` with `mavenCentral()` in Gradle repositories

## Testing
- `./gradlew :core:dependencies`

------
https://chatgpt.com/codex/tasks/task_e_686c3b0d97148326827dc0ebd1cff984