### PR TITLE
Add macOS setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,19 @@ The aim is to convert Pixel Dungeon into a fully fledged Spacebase Exploration/E
 
 Run `scripts/setup.sh` to install the Android SDK and NDK and create the required `local.properties` file. The script assumes a Debian-based system with `apt` available.
 
+### macOS
+
+macOS users can run `scripts/setup-macos.sh` instead. It uses Homebrew to
+install OpenJDK 8 and downloads the Android SDK and NDK to
+`$HOME/android-sdk`. After running the script, build the project with:
+
+```bash
+./gradlew build
+```
+
+To install the debug build on an emulator or connected device, run:
+
+```bash
+./gradlew installDebug
+```
+

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+# Setup script to prepare Android SDK/NDK and Java for building Pixel Spacebase on macOS
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+ANDROID_SDK_ROOT="$HOME/android-sdk"
+ANDROID_NDK_VERSION="26.2.11394342"
+
+if ! command -v brew >/dev/null; then
+  echo "Homebrew is required. Install from https://brew.sh/ and try again." >&2
+  exit 1
+fi
+
+# Install OpenJDK 8
+if ! brew list --formula | grep -q "openjdk@8"; then
+  brew install openjdk@8
+fi
+
+mkdir -p "$ANDROID_SDK_ROOT"
+cd "$ANDROID_SDK_ROOT"
+
+if [ ! -f "cmdline-tools/bin/sdkmanager" ]; then
+  curl -Lo cmdline-tools.zip https://dl.google.com/android/repository/commandlinetools-mac-9123335_latest.zip
+  unzip -q cmdline-tools.zip
+  rm cmdline-tools.zip
+  mv cmdline-tools cmdline-tools-temp
+  mkdir cmdline-tools
+  mv cmdline-tools-temp cmdline-tools/latest
+fi
+
+export ANDROID_HOME="$ANDROID_SDK_ROOT"
+export PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools:$PATH"
+
+yes | sdkmanager --licenses || true
+sdkmanager "platform-tools" "platforms;android-29" "build-tools;29.0.2" "ndk;$ANDROID_NDK_VERSION"
+
+cat > "$ROOT_DIR/local.properties" <<PROP
+sdk.dir=$ANDROID_SDK_ROOT
+ndk.dir=$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION
+PROP
+
+printf '\nSetup complete.\n'


### PR DESCRIPTION
## Summary
- add script to install Android SDK/NDK and OpenJDK on macOS
- document macOS setup and building instructions

## Testing
- `./gradlew --version`

------
https://chatgpt.com/codex/tasks/task_e_687c088f68548326ade68f277adf0fa6