### PR TITLE
Add local.properties for Android build

### DIFF
--- a/local.properties
+++ b/local.properties
@@ -1,0 +1,2 @@
+sdk.dir=$HOME/android-sdk
+ndk.dir=$HOME/android-sdk/ndk/26.2.11394342


### PR DESCRIPTION
## Summary
- set Android SDK and NDK paths in `local.properties`

## Testing
- `bash scripts/setup.sh` *(failed: manual cancel due to long download)*


------
https://chatgpt.com/codex/tasks/task_e_687f6b46a780832684b58ce797d9177a