### PR TITLE
Update AGP version and remove deprecated config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:8.1.0'
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    compileSdkVersion 34
+    namespace "com.wafitz.pixelspacebase"
 
     buildTypes {
         release {
@@ -27,7 +27,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:8.1.0'
     }
 }
 

--- a/pd-classes/build.gradle
+++ b/pd-classes/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    compileSdkVersion 34
+    namespace "com.watabou"
 
     task ndkBuild(type: Exec){
         description "builds JNI libs from source. " +


### PR DESCRIPTION
## Summary
- upgrade Android Gradle plugin to 8.1.0
- remove deprecated `buildToolsVersion`
- add `namespace` for AGP 8
- target latest compile SDK

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f94d1b1388326a0b9d9f5e29a0174