### PR TITLE
Fix repair blaster range and jammed chest indicator

### DIFF
--- a/core/src/main/java/com/wafitz/pixelspacebase/items/blasters/EMP.java
+++ b/core/src/main/java/com/wafitz/pixelspacebase/items/blasters/EMP.java
@@ -188,8 +188,7 @@ public class EMP extends Blaster {
         for (int c : bolt.subPath(1, dist)) {
             affectedCells.add(c);
         }
-        affectedCells.add(bolt.collisionPos);
-        if (bolt.dist + 1 < bolt.path.size()) {
+        if (bolt.dist < maxDist && bolt.dist + 1 < bolt.path.size()) {
             int blockedCell = bolt.path.get(bolt.dist + 1);
             if (isRepairableTerrain(blockedCell)) {
                 affectedCells.add(blockedCell);

--- a/core/src/main/java/com/wafitz/pixelspacebase/ui/LootIndicator.java
+++ b/core/src/main/java/com/wafitz/pixelspacebase/ui/LootIndicator.java
@@ -71,7 +71,7 @@ public class LootIndicator extends Tag {
 
                 Item item =
                         heap.type == Heap.Type.CHEST || heap.type == Heap.Type.WORKSHOP_STORAGE || heap.type == Heap.Type.CONFUSEDSHAPESHIFTER ? ItemSlot.CHEST :
-                                heap.type == Heap.Type.LOCKED_CHEST ? ItemSlot.LOCKED_CHEST :
+                                heap.type == Heap.Type.LOCKED_CHEST || heap.type == Heap.Type.JAMMED_CHEST ? ItemSlot.LOCKED_CHEST :
                                         heap.type == Heap.Type.CRYSTAL_CHEST ? ItemSlot.CRYSTAL_CHEST :
                                                 heap.type == Heap.Type.WORKSHOP_UPGRADE || heap.type == Heap.Type.CMD_TERMINAL ? ItemSlot.CMD_TERMINAL :
                                                         heap.type == Heap.Type.EMPTY_SPACESUIT ? ItemSlot.EMPTY_SPACESUIT :


### PR DESCRIPTION
Fixes #17 and #18.
- Restricts Repair Blaster affected cells to the capped beam range.
- Shows jammed chests as locked chests in the loot indicator so contents are not leaked.

Testing:
- ./gradlew test